### PR TITLE
Solve Two Issues Related to Places Markers and Popups

### DIFF
--- a/src/pages/ExplorePage/PlanPopup.tsx
+++ b/src/pages/ExplorePage/PlanPopup.tsx
@@ -7,7 +7,7 @@ const PlanPopup = ({ plan }: { plan: Plan }) => {
     <Link to={`/plans/${plan._id}`}>
       <div className="flex gap-1 sm:w-xs sm:h-32">
         <img
-          className="w-24 h-full object-cover rounded-sm hidden sm:block"
+          className="w-24 object-cover rounded-sm hidden sm:block"
           src={plan.images[0]}
           alt={plan.title}
         />

--- a/src/pages/ExplorePage/places/PlacesMarkers.tsx
+++ b/src/pages/ExplorePage/places/PlacesMarkers.tsx
@@ -12,14 +12,16 @@ const PlacesMarkers = function Markers() {
 
   const handleClick = useCallback(
     (placeId?: string, location?: [number, number]) => {
+      if (selection && placeId === selection.placeId) return;
       if (placeId) setSelection({ placeId, location, source: "marker" });
     },
-    [setSelection],
+    [selection, setSelection],
   );
 
   const handleMouseOver = useCallback(
     (placeId?: string, location?: [number, number]) => {
       if (placeId) {
+        if (selection && placeId === selection.placeId) return;
         if (mouseOverTimeoutRef.current)
           clearTimeout(mouseOverTimeoutRef.current);
         mouseOverTimeoutRef.current = window.setTimeout(
@@ -28,7 +30,7 @@ const PlacesMarkers = function Markers() {
         );
       }
     },
-    [setSelection],
+    [selection, setSelection],
   );
 
   const handleMouseOut = useCallback(

--- a/src/pages/ExplorePage/places/Popup.tsx
+++ b/src/pages/ExplorePage/places/Popup.tsx
@@ -55,9 +55,9 @@ const Popup = () => {
   if (!place) return null;
 
   return (
-    <div className="flex gap-1 sm:w-xs sm:h-32">
+    <div className="flex gap-1 sm:w-xs">
       <img
-        className="w-24 h-full object-cover rounded-sm hidden sm:block"
+        className="w-24 object-cover rounded-sm hidden sm:block"
         src={place.imageURL}
         alt={place.name}
       />

--- a/src/pages/PlanPage/Markers.tsx
+++ b/src/pages/PlanPage/Markers.tsx
@@ -53,9 +53,9 @@ const Markers = ({ stops }: { stops: StopType[] }) => {
           position={selectedPlace.location}
           onClose={handlePopupClose}
         >
-          <div className="flex gap-1 sm:w-xs sm:h-32">
+          <div className="flex gap-1 sm:w-xs">
             <img
-              className="w-24 h-full object-cover rounded-sm hidden sm:block"
+              className="w-24 object-cover rounded-sm hidden sm:block"
               src={selectedPlace.imageURL}
               alt={selectedPlace.name}
             />

--- a/src/pages/dashboard/create/Markers.tsx
+++ b/src/pages/dashboard/create/Markers.tsx
@@ -10,9 +10,10 @@ const Markers = memo(function Markers() {
 
   const handleClick = useCallback(
     (placeId?: string, location?: [number, number]) => {
+      if (selection && placeId === selection.placeId) return;
       if (placeId) setSelection({ placeId, location, source: "marker" });
     },
-    [setSelection],
+    [selection, setSelection],
   );
 
   const handlePopupClose = useCallback(() => {

--- a/src/pages/dashboard/create/PlacePopup.tsx
+++ b/src/pages/dashboard/create/PlacePopup.tsx
@@ -56,9 +56,9 @@ const PlacePopup = () => {
   if (!place) return null;
 
   return (
-    <div className="flex gap-1 sm:w-xs sm:h-32">
+    <div className="flex gap-1 sm:w-xs">
       <img
-        className="w-24 h-full object-cover rounded-sm hidden sm:block"
+        className="w-24 object-cover rounded-sm hidden sm:block"
         src={place.imageURL}
         alt={place.name}
       />


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevent duplicate marker selection and fix popup image sizing across Explore, Plan, and Dashboard pages. This stops flicker when interacting with the same marker and makes popups auto-size without stretched images.

- **Bug Fixes**
  - Ignore clicks and hovers on the already selected marker to avoid re-opening the same popup and redundant state updates.
  - Remove fixed heights from popup containers and images so content sizes naturally and images aren’t stretched.

<sup>Written for commit debb670de66c3be7b973c44dc47e7644c3cf17ca. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

